### PR TITLE
fix: strip client-forged jwtHeaders to prevent account spoofing

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -469,6 +469,16 @@ func (jwtPlugin *JwtPlugin) ServeHTTP(rw http.ResponseWriter, request *http.Requ
 }
 
 func (jwtPlugin *JwtPlugin) CheckToken(request *http.Request, rw http.ResponseWriter) (int, error) {
+	// Strip any client-supplied values for the configured jwtHeaders before
+	// doing anything else, so a forged X-Account-* header can never survive into
+	// the backend. They are re-added from verified token claims below. This runs
+	// unconditionally - including when Required is false and no/invalid token is
+	// present - because that is exactly the case where a forged header would
+	// otherwise pass through untouched.
+	for k := range jwtPlugin.jwtHeaders {
+		request.Header.Del(k)
+	}
+
 	jwtToken, err := jwtPlugin.ExtractToken(request)
 	if jwtToken == nil {
 		if jwtPlugin.required {
@@ -528,7 +538,7 @@ func (jwtPlugin *JwtPlugin) CheckToken(request *http.Request, rw http.ResponseWr
 		for k, v := range jwtPlugin.jwtHeaders {
 			_, ok := jwtToken.Payload[v]
 			if ok {
-				request.Header.Add(k, fmt.Sprint(jwtToken.Payload[v]))
+				request.Header.Set(k, fmt.Sprint(jwtToken.Payload[v]))
 			}
 		}
 	}

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -1311,3 +1311,77 @@ func mustParseUrl(urlStr string) *url.URL {
 	}
 	return u
 }
+
+// A client must never be able to forge a jwtHeaders header (e.g. X-Account-Role).
+// With a valid token the verified claim must fully replace any client-supplied
+// value, leaving exactly one value and no trace of the forged one.
+func TestServeHTTPStripsForgedHeaderWithValidToken(t *testing.T) {
+	cfg := Config{
+		JwtHeaders: map[string]string{"Name": "name"},
+		Keys:       []string{"-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnzyis1ZjfNB0bBgKFMSv\nvkTtwlvBsaJq7S5wA+kzeVOVpVWwkWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHc\naT92whREFpLv9cj5lTeJSibyr/Mrm/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIy\ntvHWTxZYEcXLgAXFuUuaS3uF9gEiNQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0\ne+lf4s4OxQawWD79J9/5d3Ry0vbV3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWb\nV6L11BWkpzGXSW4Hv43qa+GSYOD2QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9\nMwIDAQAB\n-----END PUBLIC KEY-----"},
+	}
+	ctx := context.Background()
+	nextCalled := false
+	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) { nextCalled = true })
+
+	jwt, err := New(ctx, next, &cfg, "test-traefik-jwt-plugin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := httptest.NewRecorder()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header["Authorization"] = []string{"Bearer eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.JlX3gXGyClTBFciHhknWrjo7SKqyJ5iBO0n-3S2_I7cIgfaZAeRDJ3SQEbaPxVC7X8aqGCOM-pQOjZPKUJN8DMFrlHTOdqMs0TwQ2PRBmVAxXTSOZOoEhD4ZNCHohYoyfoDhJDP4Qye_FCqu6POJzg0Jcun4d3KW04QTiGxv2PkYqmB7nHxYuJdnqE3704hIS56pc_8q6AW0WIT0W-nIvwzaSbtBU9RgaC7ZpBD2LiNE265UBIFraMDF8IAFw9itZSUCTKg1Q-q27NwwBZNGYStMdIBDor2Bsq5ge51EkWajzZ7ALisVp-bskzUsqUf77ejqX_CBAqkNdH1Zebn93A"}
+	req.Header["Name"] = []string{"Forged Attacker"}
+
+	jwt.ServeHTTP(recorder, req)
+
+	if nextCalled == false {
+		t.Fatal("next.ServeHTTP was not called")
+	}
+	values := req.Header["Name"]
+	if len(values) != 1 {
+		t.Fatalf("Expected exactly one Name header, got %d: %v", len(values), values)
+	}
+	if values[0] != "John Doe" {
+		t.Fatalf("Expected header Name:John Doe (forged value stripped), got %s", values[0])
+	}
+}
+
+// With Required:false and no token, a client-supplied jwtHeaders header must be
+// stripped, not passed through to the backend.
+func TestServeHTTPStripsForgedHeaderWithoutToken(t *testing.T) {
+	cfg := Config{
+		Required:   false,
+		JwtHeaders: map[string]string{"Name": "name"},
+	}
+	ctx := context.Background()
+	nextCalled := false
+	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) { nextCalled = true })
+
+	jwt, err := New(ctx, next, &cfg, "test-traefik-jwt-plugin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := httptest.NewRecorder()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header["Name"] = []string{"Forged Attacker"}
+
+	jwt.ServeHTTP(recorder, req)
+
+	if nextCalled == false {
+		t.Fatal("next.ServeHTTP was not called")
+	}
+	if v := req.Header.Get("Name"); v != "" {
+		t.Fatalf("Expected forged Name header to be stripped, got %s", v)
+	}
+}


### PR DESCRIPTION
### Problem

The `jwtHeaders` loop used `request.Header.Add` and never removed client-supplied values for the configured header names. A client could send e.g. `X-Account-Role: ADMIN` and it would survive alongside (and, with `Header.Add`, ahead of) the value derived from the verified token.

On `Required: false` routes with no/invalid token, the forged header passed through entirely untouched — meaning the `Del` that downstream Traefik configs *assume* happens never actually did.

### Fix

- Strip all configured `jwtHeaders` names unconditionally at the start of `CheckToken` (covers the no-token / invalid-token / missing-claim cases).
- Re-add from verified claims with `Set` instead of `Add` (verified value replaces, never appends).

### Tests

Added `TestServeHTTPStripsForgedHeaderWithValidToken` and `TestServeHTTPStripsForgedHeaderWithoutToken`. Both pass.

Note: a few pre-existing, unrelated tests (`TestServeHTTPAllowedByOPA`, `TestServeHTTPForbiddenByOPA`, `TestServeHTTPExpiration`, `TestTokenFromCookieConfiguredButNotSet`, `TestTokenFromQueryConfiguredButNotInURL`) also fail on untouched `main`; they are not affected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)